### PR TITLE
fix: Fix can't delete class with lesson plans.

### DIFF
--- a/apps/e2e/cypress/integration/plans.spec.ts
+++ b/apps/e2e/cypress/integration/plans.spec.ts
@@ -61,5 +61,12 @@ describe("Test class related features", () => {
 
     cy.contains("All plans").click()
     cy.contains(secondName).should("be.visible")
+
+    // Regression test, should be able to delete class
+    cy.visit("/dashboard/settings/class")
+    cy.contains(className).click()
+    cy.contains("Delete").click()
+    cy.contains("Yes").click()
+    cy.contains(className).should("not.be.visible")
   })
 })

--- a/apps/vor/frontend/graphql-types.ts
+++ b/apps/vor/frontend/graphql-types.ts
@@ -1485,6 +1485,8 @@ export type QueryAllSitePageArgs = {
 export type QuerySiteArgs = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<DateQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;
@@ -1568,6 +1570,8 @@ export type QueryAllSitePluginArgs = {
 export type Site = Node & {
   buildTime?: Maybe<Scalars['Date']>;
   siteMetadata?: Maybe<SiteSiteMetadata>;
+  port?: Maybe<Scalars['Date']>;
+  host?: Maybe<Scalars['String']>;
   polyfill?: Maybe<Scalars['Boolean']>;
   pathPrefix?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
@@ -1578,6 +1582,14 @@ export type Site = Node & {
 
 
 export type SiteBuildTimeArgs = {
+  formatString?: Maybe<Scalars['String']>;
+  fromNow?: Maybe<Scalars['Boolean']>;
+  difference?: Maybe<Scalars['String']>;
+  locale?: Maybe<Scalars['String']>;
+};
+
+
+export type SitePortArgs = {
   formatString?: Maybe<Scalars['String']>;
   fromNow?: Maybe<Scalars['Boolean']>;
   difference?: Maybe<Scalars['String']>;
@@ -1770,6 +1782,8 @@ export type SiteFieldsEnum =
   'siteMetadata___title' |
   'siteMetadata___description' |
   'siteMetadata___author' |
+  'port' |
+  'host' |
   'polyfill' |
   'pathPrefix' |
   'id' |
@@ -1862,6 +1876,8 @@ export type SiteFieldsEnum =
 export type SiteFilterInput = {
   buildTime?: Maybe<DateQueryOperatorInput>;
   siteMetadata?: Maybe<SiteSiteMetadataFilterInput>;
+  port?: Maybe<DateQueryOperatorInput>;
+  host?: Maybe<StringQueryOperatorInput>;
   polyfill?: Maybe<BooleanQueryOperatorInput>;
   pathPrefix?: Maybe<StringQueryOperatorInput>;
   id?: Maybe<StringQueryOperatorInput>;

--- a/apps/vor/pkg/postgres/postgres.go
+++ b/apps/vor/pkg/postgres/postgres.go
@@ -248,7 +248,7 @@ type (
 		Id                string `pg:"type:uuid"`
 		Title             string
 		Description       *string
-		ClassId           string `pg:"type:uuid"`
+		ClassId           string `pg:"type:uuid,on_delete:SET NULL"`
 		Class             Class
 		Files             []File `pg:"many2many:file_to_lesson_plans,joinFK:file_id"`
 		RepetitionType    int    `pg:",use_zero"`
@@ -264,7 +264,7 @@ type (
 
 	File struct {
 		Id          string `pg:"type:uuid,pk"`
-		SchoolId    string `pg:"type:uuid"`
+		SchoolId    string `pg:"type:uuid,on_delete:CASCADE"`
 		School      School
 		FileName    string
 		LessonPlans []LessonPlan `pg:"many2many:file_to_lesson_plans,joinFK:lesson_plan_id"`


### PR DESCRIPTION
Trying to delete a class that have lesson plans attached to it causees the server to return 500. This is because the lesson plan's foreign key does not have any on delete rules.