### PR TITLE
ref: Rename Details field in lesson plan to LessonPlanDetails

### DIFF
--- a/apps/vor/go.sum
+++ b/apps/vor/go.sum
@@ -47,8 +47,6 @@ github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NB
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
-github.com/go-chi/chi v4.1.1+incompatible h1:MmTgB0R8Bt/jccxp+t6S/1VGIKdJw5J74CK/c9tTfA4=
-github.com/go-chi/chi v4.1.1+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.1.2+incompatible h1:fGFk2Gmi/YKXk0OmGfBh0WgmN3XB8lVnEyNz34tQRec=
 github.com/go-chi/chi v4.1.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-errors/errors v1.0.1 h1:LUHzmkK3GUKUrL/1gfBUxAHzcev3apQlezX/+O7ma6w=
@@ -136,8 +134,6 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/mailgun/mailgun-go/v4 v4.1.0 h1:uLpVaYVGUn140doqoYoWscVnFis6x+0c8befRvXG6Z4=
-github.com/mailgun/mailgun-go/v4 v4.1.0/go.mod h1:R9kHUQBptF4iSEjhriCQizplCDwrnDShy8w/iPiOfaM=
 github.com/mailgun/mailgun-go/v4 v4.1.1 h1:RqQK52IobBUDuBFq90ngRKQLYxJ2TexkKzwXW70rNYk=
 github.com/mailgun/mailgun-go/v4 v4.1.1/go.mod h1:R9kHUQBptF4iSEjhriCQizplCDwrnDShy8w/iPiOfaM=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
@@ -150,8 +146,6 @@ github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpe
 github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.mod h1:dSsfyI2zABAdhcbvkXqgxOxrCsbYeHCPgrZkku60dSg=
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
-github.com/minio/minio-go/v6 v6.0.55 h1:Hqm41952DdRNKXM+6hCnPXCsHCYSgLf03iuYoxJG2Wk=
-github.com/minio/minio-go/v6 v6.0.55/go.mod h1:KQMM+/44DSlSGSQWSfRrAZ12FVMmpWNuX37i2AX0jfI=
 github.com/minio/minio-go/v6 v6.0.56 h1:H4+v6UFV1V7VkEf1HjL15W9OvTL1Gy8EbMmjQZHqEbg=
 github.com/minio/minio-go/v6 v6.0.56/go.mod h1:KQMM+/44DSlSGSQWSfRrAZ12FVMmpWNuX37i2AX0jfI=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
@@ -212,8 +206,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
@@ -264,8 +257,6 @@ golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1 h1:anGSYQpPhQwXlwsu5wmfq0
 golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d h1:1ZiEyfaQIg3Qh0EoqpwAakHVhecoE5wlSg5GjnafJGw=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 h1:cg5LA/zNPRzIXIWSCxQW10Rvpy94aQh3LT/ShoCpkHw=
-golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
@@ -352,6 +343,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/apps/vor/pkg/class/test/lesson_plan_test.go
+++ b/apps/vor/pkg/class/test/lesson_plan_test.go
@@ -36,11 +36,11 @@ func (s *ClassTestSuite) TestPostNewLessonPlan() {
 	var plan postgres.LessonPlan
 	err := s.DB.Model(&plan).
 		Where("date=?", payload.Date).
-		Relation("Details").
+		Relation("LessonPlanDetails").
 		Select()
 	assert.NoError(t, err)
-	assert.Equal(t, payload.Title, plan.Details.Title)
-	assert.Equal(t, payload.Description, *plan.Details.Description)
+	assert.Equal(t, payload.Title, plan.LessonPlanDetails.Title)
+	assert.Equal(t, payload.Description, *plan.LessonPlanDetails.Description)
 	assert.Equal(t, payload.Date.Unix(), plan.Date.Unix())
-	assert.Equal(t, len(payload.FileIds), len(plan.Details.Files))
+	assert.Equal(t, len(payload.FileIds), len(plan.LessonPlanDetails.Files))
 }

--- a/apps/vor/pkg/postgres/lessonplanStore.go
+++ b/apps/vor/pkg/postgres/lessonplanStore.go
@@ -23,9 +23,9 @@ func (s LessonPlanStore) CreateLessonPlan(planInput cLessonPlan.PlanData) (*cLes
 
 	var plans []LessonPlan
 	plans = append(plans, LessonPlan{
-		Id:        uuid.New().String(),
-		Date:      &planInput.Date,
-		DetailsId: planDetails.Id,
+		Id:                  uuid.New().String(),
+		Date:                &planInput.Date,
+		LessonPlanDetailsId: planDetails.Id,
 	})
 	// Create all instance of repeating plans and save to db. This will make it easy to
 	// retrieve, modify, and attach metadata to individual instances of the plans down the road
@@ -51,9 +51,9 @@ func (s LessonPlanStore) CreateLessonPlan(planInput cLessonPlan.PlanData) (*cLes
 				break
 			}
 			plans = append(plans, LessonPlan{
-				Id:        uuid.New().String(),
-				Date:      &currentDate,
-				DetailsId: planDetails.Id,
+				Id:                  uuid.New().String(),
+				Date:                &currentDate,
+				LessonPlanDetailsId: planDetails.Id,
 			})
 		}
 	}
@@ -105,7 +105,7 @@ func (s LessonPlanStore) UpdateLessonPlan(planInput cLessonPlan.UpdatePlanData) 
 		Date: planInput.Date,
 	}
 	planDetails := LessonPlanDetails{
-		Id:          originalPlan.DetailsId,
+		Id:          originalPlan.LessonPlanDetailsId,
 		Description: planInput.Description,
 	}
 	if planInput.Title != nil {
@@ -141,7 +141,7 @@ func (s LessonPlanStore) GetLessonPlan(planId string) (*cLessonPlan.LessonPlan, 
 	var plan LessonPlan
 
 	err := s.Model(&plan).
-		Relation("Details").
+		Relation("LessonPlanDetails").
 		Where("lesson_plan.id = ?", planId).
 		Select()
 
@@ -154,13 +154,13 @@ func (s LessonPlanStore) GetLessonPlan(planId string) (*cLessonPlan.LessonPlan, 
 
 	return &cLessonPlan.LessonPlan{
 		Id:          plan.Id,
-		ClassId:     plan.Details.ClassId,
-		Title:       plan.Details.Title,
-		Description: *plan.Details.Description,
+		ClassId:     plan.LessonPlanDetails.ClassId,
+		Title:       plan.LessonPlanDetails.Title,
+		Description: *plan.LessonPlanDetails.Description,
 		Date:        *plan.Date,
 		Repetition: &cLessonPlan.RepetitionPattern{
-			Type:    plan.Details.RepetitionType,
-			EndDate: plan.Details.RepetitionEndDate,
+			Type:    plan.LessonPlanDetails.RepetitionType,
+			EndDate: plan.LessonPlanDetails.RepetitionEndDate,
 		},
 	}, nil
 }

--- a/apps/vor/pkg/postgres/postgres.go
+++ b/apps/vor/pkg/postgres/postgres.go
@@ -253,13 +253,14 @@ type (
 		Files             []File `pg:"many2many:file_to_lesson_plans,joinFK:file_id"`
 		RepetitionType    int    `pg:",use_zero"`
 		RepetitionEndDate time.Time
+		LessonPlans       []*LessonPlan
 	}
 
 	LessonPlan struct {
-		Id        string     `pg:"type:uuid"`
-		Date      *time.Time `pg:",notnull"`
-		DetailsId string     `pg:"type:uuid"`
-		Details   LessonPlanDetails
+		Id                  string     `pg:"type:uuid"`
+		Date                *time.Time `pg:",notnull"`
+		LessonPlanDetailsId string     `pg:"type:uuid"`
+		LessonPlanDetails   LessonPlanDetails
 	}
 
 	File struct {

--- a/apps/vor/pkg/postgres/schoolStore.go
+++ b/apps/vor/pkg/postgres/schoolStore.go
@@ -423,8 +423,8 @@ func (s SchoolStore) GetLessonPlans(schoolId string, date time.Time) ([]cSchool.
 	res := make([]cSchool.LessonPlan, 0)
 	if err := s.DB.Model(&lessonPlan).
 		Where("date::date=?", date).
-		Relation("Details").
-		Relation("Details.Class", func(q *orm.Query) (*orm.Query, error) {
+		Relation("LessonPlanDetails").
+		Relation("LessonPlanDetails.Class", func(q *orm.Query) (*orm.Query, error) {
 			return q.Where("school_id = ?", schoolId), nil
 		}).
 		Select(); err != nil {
@@ -433,13 +433,13 @@ func (s SchoolStore) GetLessonPlans(schoolId string, date time.Time) ([]cSchool.
 	for _, plan := range lessonPlan {
 		newPlan := cSchool.LessonPlan{
 			Id:        plan.Id,
-			Title:     plan.Details.Title,
-			ClassId:   plan.Details.ClassId,
-			ClassName: plan.Details.Class.Name,
+			Title:     plan.LessonPlanDetails.Title,
+			ClassId:   plan.LessonPlanDetails.ClassId,
+			ClassName: plan.LessonPlanDetails.Class.Name,
 			Date:      *plan.Date,
 		}
-		if plan.Details.Description != nil {
-			newPlan.Description = *plan.Details.Description
+		if plan.LessonPlanDetails.Description != nil {
+			newPlan.Description = *plan.LessonPlanDetails.Description
 		}
 		res = append(res, newPlan)
 	}

--- a/apps/vor/pkg/school/test/lesson_plan_test.go
+++ b/apps/vor/pkg/school/test/lesson_plan_test.go
@@ -13,7 +13,7 @@ func (s *SchoolTestSuite) TestGetLessonPlan() {
 	gofakeit.Seed(time.Now().UnixNano())
 	lessonPlan, userId := s.SaveNewLessonPlan()
 
-	url := "/" + lessonPlan.Details.Class.School.Id + "/plans?date=" + lessonPlan.Date.Format(time.RFC3339)
+	url := "/" + lessonPlan.LessonPlanDetails.Class.School.Id + "/plans?date=" + lessonPlan.Date.Format(time.RFC3339)
 	result := s.CreateRequest("GET", url, nil, &userId)
 	assert.Equal(t, http.StatusOK, result.Code)
 
@@ -29,5 +29,5 @@ func (s *SchoolTestSuite) TestGetLessonPlan() {
 	assert.NoError(t, err)
 
 	assert.Len(t, body, 1)
-	assert.Equal(t, lessonPlan.Details.Title, body[0].Title)
+	assert.Equal(t, lessonPlan.LessonPlanDetails.Title, body[0].Title)
 }

--- a/apps/vor/pkg/school/test/school_test.go
+++ b/apps/vor/pkg/school/test/school_test.go
@@ -89,10 +89,10 @@ func (s *SchoolTestSuite) SaveNewLessonPlan() (*postgres.LessonPlan, string) {
 	}
 	date := gofakeit.Date()
 	newLessonPlan := postgres.LessonPlan{
-		Id:        uuid.New().String(),
-		Date:      &date,
-		DetailsId: details.Id,
-		Details:   details,
+		Id:                  uuid.New().String(),
+		Date:                &date,
+		LessonPlanDetailsId: details.Id,
+		LessonPlanDetails:   details,
 	}
 	err := s.DB.Insert(&details)
 	assert.NoError(t, err)


### PR DESCRIPTION
This is done so that go-pg can clearly tell the relationship between LessonPlanDetails and LessonPlan. This way we can query LessonPlanDetails and get the LessonPlan instances using go-pg's Relation method.