### PR TITLE
feat: Accept multipart/form-data on post new file endpoint.

### DIFF
--- a/apps/vor/pkg/postgres/schoolStore.go
+++ b/apps/vor/pkg/postgres/schoolStore.go
@@ -464,19 +464,16 @@ func (s SchoolStore) GetLessonFiles(schoolId string) ([]cSchool.File, error) {
 	return result, nil
 }
 
-func (s SchoolStore) CreateFile(schoolId, file string) (*cSchool.File, error) {
-	obj := File{
+func (s SchoolStore) CreateFile(schoolId, file string) (*string, error) {
+	newFile := File{
 		Id:       uuid.New().String(),
 		SchoolId: schoolId,
 		Name:     file,
 	}
-	if err := s.Insert(&obj); err != nil {
+	if err := s.Insert(&newFile); err != nil {
 		return nil, richErrors.Wrap(err, "failed to create file:")
 	}
-	return &cSchool.File{
-		Id:   obj.Id,
-		Name: obj.Name,
-	}, nil
+	return &newFile.Id, nil
 }
 
 func (s SchoolStore) DeleteFile(fileId string) error {

--- a/apps/vor/pkg/school/school.go
+++ b/apps/vor/pkg/school/school.go
@@ -50,6 +50,7 @@ func NewRouter(
 
 		r.Method("GET", "/files", getLessonFiles(server, store))
 		r.Method("POST", "/files", addFile(server, store))
+		// TODO: Might be better to be on its own root path.
 		r.Method("PATCH", "/files/{fileId}", updateFile(server, store))
 		r.Method("DELETE", "/files/{fileId}", deleteFile(server, store))
 	})
@@ -751,31 +752,30 @@ func getLessonFiles(server rest.Server, store Store) http.Handler {
 }
 
 func addFile(server rest.Server, store Store) http.Handler {
-	type reqBody struct {
-		FileName string `json:"fileName"`
-	}
-
 	type resBody struct {
-		Id   string `json:"id"`
-		Name string `json:"name"`
+		Id string `json:"id"`
 	}
-
 	return server.NewHandler(func(w http.ResponseWriter, r *http.Request) *rest.Error {
-		body := reqBody{}
 		schoolId := chi.URLParam(r, "schoolId")
 
-		if err := rest.ParseJson(r.Body, &body); err != nil {
-			return rest.NewParseJsonError(err)
-		}
-
-		if body.FileName == "" {
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
 			return &rest.Error{
 				Code:    http.StatusBadRequest,
-				Message: "File name must not empty",
+				Message: "failed to parse payload",
+				Error:   richErrors.Wrap(err, "failed to parse response body"),
 			}
 		}
 
-		res, err := store.CreateFile(schoolId, body.FileName)
+		_, fileHeader, err := r.FormFile("file")
+		if err != nil {
+			return &rest.Error{
+				Code:    http.StatusBadRequest,
+				Message: "invalid payload",
+				Error:   richErrors.Wrap(err, "invalid payload"),
+			}
+		}
+
+		id, err := store.CreateFile(schoolId, fileHeader.Filename)
 		if err != nil {
 			return &rest.Error{
 				Code:    http.StatusInternalServerError,
@@ -785,10 +785,7 @@ func addFile(server rest.Server, store Store) http.Handler {
 		}
 
 		w.WriteHeader(http.StatusCreated)
-		if err := rest.WriteJson(w, &resBody{
-			Id:   res.Id,
-			Name: res.Name,
-		}); err != nil {
+		if err := rest.WriteJson(w, &resBody{*id}); err != nil {
 			return rest.NewWriteJsonError(err)
 		}
 		return nil

--- a/apps/vor/pkg/school/store.go
+++ b/apps/vor/pkg/school/store.go
@@ -124,7 +124,7 @@ type (
 		GetSchoolClasses(schoolId string) ([]Class, error)
 		InsertGuardianWithRelation(input GuardianWithRelation) (*Guardian, error)
 		GetGuardians(schoolId string) ([]Guardian, error)
-		CreateFile(schoolId, file string) (*File, error)
+		CreateFile(schoolId, file string) (*string, error)
 		DeleteFile(fileId string) error
 		UpdateFile(fileId, fileName string) (*File, error)
 		GetLessonPlans(schoolId string, date time.Time) ([]LessonPlan, error)

--- a/apps/vor/pkg/school/test/file_test.go
+++ b/apps/vor/pkg/school/test/file_test.go
@@ -1,0 +1,56 @@
+package school_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/brianvoe/gofakeit/v4"
+	"github.com/chrsep/vor/pkg/postgres"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"time"
+)
+
+func (s *SchoolTestSuite) TestUploadFile() {
+	t := s.T()
+	gofakeit.Seed(time.Now().UnixNano())
+	school := s.SaveNewSchool()
+
+	fileName := gofakeit.Name()
+	filePath := "testfile.txt"
+
+	// Read file contents
+	file, err := os.Open(filePath)
+	assert.NoError(t, err)
+	fileContents, err := ioutil.ReadAll(file)
+	assert.NoError(t, err)
+	err = file.Close()
+	assert.NoError(t, err)
+
+	// Write file to multipart/form-data
+	payload := new(bytes.Buffer)
+	writer := multipart.NewWriter(payload)
+	part, err := writer.CreateFormFile("file", fileName)
+	assert.NoError(t, err)
+	_, err = part.Write(fileContents)
+	assert.NoError(t, err)
+	err = writer.Close()
+	assert.NoError(t, err)
+
+	result := s.CreateMultipartRequest("/"+school.Id+"/files", payload, writer.Boundary(), &school.Users[0].Id)
+	assert.Equal(t, result.Code, http.StatusCreated)
+
+	var response struct {
+		Id string `json:"id"`
+	}
+	err = json.Unmarshal(result.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	fileSaved := postgres.File{Id: response.Id}
+	err = s.DB.Model(&fileSaved).WherePK().Select()
+	assert.NoError(t, err)
+
+	assert.Equal(t, fileName, fileSaved.Name)
+}

--- a/apps/vor/pkg/school/test/testfile.txt
+++ b/apps/vor/pkg/school/test/testfile.txt
@@ -1,0 +1,1 @@
+This is a test


### PR DESCRIPTION
- Now POST `/schools/{schoolId}/files` accepts multipart/form and accepts 1 file as input
- Filenames are now taken directly from multipart/form file
- Add test for file upload