### PR TITLE
ref: Add FileStorage interface to schoolStore.

### DIFF
--- a/apps/vor/pkg/main.go
+++ b/apps/vor/pkg/main.go
@@ -69,7 +69,6 @@ func runServer() error {
 	server := rest.NewServer(l)
 	studentStore := postgres.StudentStore{db}
 	observationStore := postgres.ObservationStore{db}
-	schoolStore := postgres.SchoolStore{db}
 	userStore := postgres.UserStore{db}
 	curriculumStore := postgres.CurriculumStore{db}
 	authStore := postgres.AuthStore{db}
@@ -89,6 +88,8 @@ func runServer() error {
 		return err
 	}
 	imageStorage := minio.NewImageStorage(minioClient)
+	fileStorage := minio.NewFileStorage(minioClient)
+	schoolStore := postgres.SchoolStore{db, fileStorage}
 
 	// Setup routing
 	r := chi.NewRouter()

--- a/apps/vor/pkg/minio/fileStorage.go
+++ b/apps/vor/pkg/minio/fileStorage.go
@@ -5,14 +5,26 @@ import (
 	"os"
 )
 
-type FileStorage struct {
-	*minio.Client
-	bucketName string
-}
-
 func NewFileStorage(client *minio.Client) *FileStorage {
 	bucketName := os.Getenv("MINIO_BUCKET_NAME")
 
 	fileStorage := FileStorage{client, bucketName}
 	return &fileStorage
+}
+
+type FileStorage struct {
+	*minio.Client
+	bucketName string
+}
+
+func (f FileStorage) Save(schoolId string, fileId string) (string, error) {
+	panic("implement me")
+}
+
+func (f FileStorage) Delete(schoolId string, fileId string) (string, error) {
+	panic("implement me")
+}
+
+func (f FileStorage) GetUrl(schoolId string, fileId string) string {
+	panic("implement me")
 }

--- a/apps/vor/pkg/postgres/fileStorage.go
+++ b/apps/vor/pkg/postgres/fileStorage.go
@@ -1,0 +1,7 @@
+package postgres
+
+type FileStorage interface {
+	Save(schoolId string, fileId string) (string, error)
+	Delete(schoolId string, fileId string) (string, error)
+	GetUrl(schoolId string, fileId string) string
+}

--- a/apps/vor/pkg/postgres/schoolStore.go
+++ b/apps/vor/pkg/postgres/schoolStore.go
@@ -11,11 +11,10 @@ import (
 	cSchool "github.com/chrsep/vor/pkg/school"
 )
 
-type (
-	SchoolStore struct {
-		*pg.DB
-	}
-)
+type SchoolStore struct {
+	*pg.DB
+	FileStorage FileStorage
+}
 
 func (s SchoolStore) NewSchool(schoolName, userId string) (*cSchool.School, error) {
 	id := uuid.New()

--- a/apps/vor/pkg/school/school.go
+++ b/apps/vor/pkg/school/school.go
@@ -370,6 +370,7 @@ func postNewStudent(s rest.Server, store Store, storage StudentImageStorage) res
 		picture, pictureFileHeader, err := r.FormFile("picture")
 		var profilePicPath string
 		if err == nil {
+			// TODO: Do we need to read the file header here? We already have pictureFileHeader above?
 			fileHeader := make([]byte, 512)
 			if _, err := picture.Read(fileHeader); err != nil {
 				return &rest.Error{

--- a/apps/vor/pkg/school/test/school_test.go
+++ b/apps/vor/pkg/school/test/school_test.go
@@ -21,7 +21,7 @@ type SchoolTestSuite struct {
 }
 
 func (s *SchoolTestSuite) SetupTest() {
-	s.store = postgres.SchoolStore{s.DB}
+	s.store = postgres.SchoolStore{s.DB, nil}
 	s.StudentImageStorage = mocks.StudentImageStorage{}
 	s.Handler = school.NewRouter(s.Server, s.store, &s.StudentImageStorage, nil).ServeHTTP
 }


### PR DESCRIPTION
In order to shift the responsibility of wrangling data saving and deleting out of the handlers, FileStorage interface is now added to the schoolStore directly.

An example of the data flow will look like this:
1. Handler for post `/schools/{schoolId}/files` receives a request containing a file.
2. It passes the file, the name of the file and the schoolId to the schoolStore.
3. SchoolStore will then try to save it to minio using FileStorage interface.
4. On successful file save, it will then save the record to db.

Here instead of the handler having to pass save the file, check if it is successful and then save the data to the db, we can just let schoolStore deal with those and let the handler deal with the data mapping and request/response validation.