### PR TITLE
fix: don't redirect root path with 302

### DIFF
--- a/apps/e2e/cypress/integration/pwa.spec.ts
+++ b/apps/e2e/cypress/integration/pwa.spec.ts
@@ -42,11 +42,13 @@ describe("test pwa works correctly", () => {
     cy.visit("/")
     cy.url().should("contains", "dashboard")
 
-    // so does third visit
-    cy.visit("/")
-    cy.url().should("contains", "dashboard")
-    cy.visit("/login")
-    cy.url().should("contains", "dashboard")
+    // so does every other visits visit
+    for (let i = 0; i < 10; i += 1) {
+      cy.visit("/")
+      cy.url().should("contains", "dashboard")
+      cy.visit("/login")
+      cy.url().should("contains", "dashboard")
+    }
 
     // shouldn't be able to visit dashboard after logging out
     cy.request("POST", "auth/logout")

--- a/apps/vor/frontend/graphql-types.ts
+++ b/apps/vor/frontend/graphql-types.ts
@@ -2105,12 +2105,12 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___showSpinner'
   | 'pluginCreator___pluginOptions___dsn'
   | 'pluginCreator___pluginOptions___release'
-  | 'pluginCreator___pluginOptions___analyzerPort'
-  | 'pluginCreator___pluginOptions___disable'
-  | 'pluginCreator___pluginOptions___pathCheck'
   | 'pluginCreator___pluginOptions___codegen'
   | 'pluginCreator___pluginOptions___fileName'
   | 'pluginCreator___pluginOptions___documentPaths'
+  | 'pluginCreator___pluginOptions___analyzerPort'
+  | 'pluginCreator___pluginOptions___disable'
+  | 'pluginCreator___pluginOptions___pathCheck'
   | 'pluginCreator___nodeAPIs'
   | 'pluginCreator___browserAPIs'
   | 'pluginCreator___ssrAPIs'
@@ -2327,12 +2327,12 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___showSpinner'
   | 'pluginOptions___dsn'
   | 'pluginOptions___release'
-  | 'pluginOptions___analyzerPort'
-  | 'pluginOptions___disable'
-  | 'pluginOptions___pathCheck'
   | 'pluginOptions___codegen'
   | 'pluginOptions___fileName'
   | 'pluginOptions___documentPaths'
+  | 'pluginOptions___analyzerPort'
+  | 'pluginOptions___disable'
+  | 'pluginOptions___pathCheck'
   | 'nodeAPIs'
   | 'browserAPIs'
   | 'ssrAPIs'
@@ -2472,12 +2472,12 @@ export type SitePluginPluginOptions = {
   showSpinner?: Maybe<Scalars['Boolean']>;
   dsn?: Maybe<Scalars['String']>;
   release?: Maybe<Scalars['String']>;
-  analyzerPort?: Maybe<Scalars['Int']>;
-  disable?: Maybe<Scalars['Boolean']>;
-  pathCheck?: Maybe<Scalars['Boolean']>;
   codegen?: Maybe<Scalars['Boolean']>;
   fileName?: Maybe<Scalars['String']>;
   documentPaths?: Maybe<Array<Maybe<Scalars['String']>>>;
+  analyzerPort?: Maybe<Scalars['Int']>;
+  disable?: Maybe<Scalars['Boolean']>;
+  pathCheck?: Maybe<Scalars['Boolean']>;
 };
 
 export type SitePluginPluginOptionsFilterInput = {
@@ -2508,12 +2508,12 @@ export type SitePluginPluginOptionsFilterInput = {
   showSpinner?: Maybe<BooleanQueryOperatorInput>;
   dsn?: Maybe<StringQueryOperatorInput>;
   release?: Maybe<StringQueryOperatorInput>;
-  analyzerPort?: Maybe<IntQueryOperatorInput>;
-  disable?: Maybe<BooleanQueryOperatorInput>;
-  pathCheck?: Maybe<BooleanQueryOperatorInput>;
   codegen?: Maybe<BooleanQueryOperatorInput>;
   fileName?: Maybe<StringQueryOperatorInput>;
   documentPaths?: Maybe<StringQueryOperatorInput>;
+  analyzerPort?: Maybe<IntQueryOperatorInput>;
+  disable?: Maybe<BooleanQueryOperatorInput>;
+  pathCheck?: Maybe<BooleanQueryOperatorInput>;
 };
 
 export type SitePluginPluginOptionsFonts = {

--- a/apps/vor/frontend/graphql-types.ts
+++ b/apps/vor/frontend/graphql-types.ts
@@ -2105,12 +2105,12 @@ export type SitePageFieldsEnum =
   | 'pluginCreator___pluginOptions___showSpinner'
   | 'pluginCreator___pluginOptions___dsn'
   | 'pluginCreator___pluginOptions___release'
-  | 'pluginCreator___pluginOptions___codegen'
-  | 'pluginCreator___pluginOptions___fileName'
-  | 'pluginCreator___pluginOptions___documentPaths'
   | 'pluginCreator___pluginOptions___analyzerPort'
   | 'pluginCreator___pluginOptions___disable'
   | 'pluginCreator___pluginOptions___pathCheck'
+  | 'pluginCreator___pluginOptions___codegen'
+  | 'pluginCreator___pluginOptions___fileName'
+  | 'pluginCreator___pluginOptions___documentPaths'
   | 'pluginCreator___nodeAPIs'
   | 'pluginCreator___browserAPIs'
   | 'pluginCreator___ssrAPIs'
@@ -2327,12 +2327,12 @@ export type SitePluginFieldsEnum =
   | 'pluginOptions___showSpinner'
   | 'pluginOptions___dsn'
   | 'pluginOptions___release'
-  | 'pluginOptions___codegen'
-  | 'pluginOptions___fileName'
-  | 'pluginOptions___documentPaths'
   | 'pluginOptions___analyzerPort'
   | 'pluginOptions___disable'
   | 'pluginOptions___pathCheck'
+  | 'pluginOptions___codegen'
+  | 'pluginOptions___fileName'
+  | 'pluginOptions___documentPaths'
   | 'nodeAPIs'
   | 'browserAPIs'
   | 'ssrAPIs'
@@ -2472,12 +2472,12 @@ export type SitePluginPluginOptions = {
   showSpinner?: Maybe<Scalars['Boolean']>;
   dsn?: Maybe<Scalars['String']>;
   release?: Maybe<Scalars['String']>;
-  codegen?: Maybe<Scalars['Boolean']>;
-  fileName?: Maybe<Scalars['String']>;
-  documentPaths?: Maybe<Array<Maybe<Scalars['String']>>>;
   analyzerPort?: Maybe<Scalars['Int']>;
   disable?: Maybe<Scalars['Boolean']>;
   pathCheck?: Maybe<Scalars['Boolean']>;
+  codegen?: Maybe<Scalars['Boolean']>;
+  fileName?: Maybe<Scalars['String']>;
+  documentPaths?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
 
 export type SitePluginPluginOptionsFilterInput = {
@@ -2508,12 +2508,12 @@ export type SitePluginPluginOptionsFilterInput = {
   showSpinner?: Maybe<BooleanQueryOperatorInput>;
   dsn?: Maybe<StringQueryOperatorInput>;
   release?: Maybe<StringQueryOperatorInput>;
-  codegen?: Maybe<BooleanQueryOperatorInput>;
-  fileName?: Maybe<StringQueryOperatorInput>;
-  documentPaths?: Maybe<StringQueryOperatorInput>;
   analyzerPort?: Maybe<IntQueryOperatorInput>;
   disable?: Maybe<BooleanQueryOperatorInput>;
   pathCheck?: Maybe<BooleanQueryOperatorInput>;
+  codegen?: Maybe<BooleanQueryOperatorInput>;
+  fileName?: Maybe<StringQueryOperatorInput>;
+  documentPaths?: Maybe<StringQueryOperatorInput>;
 };
 
 export type SitePluginPluginOptionsFonts = {

--- a/apps/vor/frontend/src/pages/index.tsx
+++ b/apps/vor/frontend/src/pages/index.tsx
@@ -1,12 +1,12 @@
 import { PageRendererProps } from "gatsby"
-import React, { FC } from "react"
+import React, { FC, useEffect } from "react"
 import { navigate } from "../components/Link/Link"
 import { STUDENTS_URL } from "../routes"
 
-const IndexPage: FC<PageRendererProps> = ({ location }) => {
-  if (typeof window !== "undefined" && location.pathname === "/") {
+const IndexPage: FC<PageRendererProps> = () => {
+  useEffect(() => {
     navigate(STUDENTS_URL)
-  }
+  }, [])
   return <div />
 }
 

--- a/apps/vor/frontend/src/pages/index.tsx
+++ b/apps/vor/frontend/src/pages/index.tsx
@@ -1,9 +1,10 @@
-import { PageRendererProps } from "gatsby"
+import { PageRendererProps, navigate } from "gatsby"
 import React, { FC, useEffect } from "react"
-import { navigate } from "../components/Link/Link"
 import { STUDENTS_URL } from "../routes"
 
 const IndexPage: FC<PageRendererProps> = () => {
+  // TODO: replace with gatsby's newly exported Redirect component when it lands
+  //  (gatsby #26046)
   useEffect(() => {
     navigate(STUDENTS_URL)
   }, [])

--- a/apps/vor/pkg/frontend.go
+++ b/apps/vor/pkg/frontend.go
@@ -54,7 +54,7 @@ func createFrontendAuthMiddleware(db *pg.DB, folder string) func(next http.Handl
 			}
 
 			// Remove trailing slashes
-			if strings.HasSuffix(path, "/") {
+			if strings.HasSuffix(path, "/") && path != "/" {
 				http.Redirect(w, r, strings.TrimSuffix(path, "/"), http.StatusMovedPermanently)
 				return
 			}

--- a/apps/vor/pkg/frontend.go
+++ b/apps/vor/pkg/frontend.go
@@ -48,7 +48,7 @@ func createFrontendAuthMiddleware(db *pg.DB, folder string) func(next http.Handl
 			}
 
 			// If trying to access root, redirect to dashboard
-			if path == "/" || path == "/dashboard" || path == "/dashboard/" || path == "/dashboard/home" {
+			if path == "/dashboard" || path == "/dashboard/" || path == "/dashboard/home" {
 				http.Redirect(w, r, "/dashboard/students", http.StatusFound)
 				return
 			}


### PR DESCRIPTION
Currently, the root path is being redirected with 302 when the user is logged in. This causes the service worker to be unable to cache the root path. This, in turn, makes users that open root path always need to send requests to the server, defeating the service worker's purpose.

To mitigate this, the root path won't redirect with 302 anymore. Instead, it will serve a blank page, that will redirect users client-side. This will allow the service worker to cache the root path and everything will be served instantly.