### PR TITLE
fix cache key.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
             .pnp.js
             apps/vor/frontend/public
             apps/vor/frontend/.cache
-          key: v2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
@@ -66,7 +66,7 @@ jobs:
             .yarn/build-state.yml
             .pnp.js
             apps/gaia/.next
-          key: v2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
@@ -160,7 +160,7 @@ jobs:
             .yarn/install-state.gz
             .yarn/build-state.yml
             .pnp.js
-          key: v2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v2-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
@@ -208,7 +208,7 @@ jobs:
             .yarn/build-state.yml
             .pnp.js
             ~/.cache/Cypress
-          key: v3-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v3-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -29,7 +29,7 @@ jobs:
           path: |
             .yarn
             .pnp.js
-          key: v1-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v1-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }-${{ hashFiles('**/yarn.lock') }}}
       - name: Setup git creds
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -33,7 +33,7 @@ jobs:
             .yarn/install-state.gz
             .yarn/build-state.yml
             .pnp.js
-          key: v1-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v1-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
@@ -59,7 +59,7 @@ jobs:
             .yarn/install-state.gz
             .yarn/build-state.yml
             .pnp.js
-          key: v1-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}
+          key: v1-${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pnp.js') }}-${{ hashFiles('**/yarn.lock') }}
       - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
We use both .pnp.js and yarn.lock as cache key to make sure that the cache gets busted after update deps runs and makes some changes to .pnp.js